### PR TITLE
Fix payment pages layout and add receipt support

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -6,8 +6,7 @@
   <title>Панель управления платежами</title>
   <link rel="stylesheet" href="styles.css">
 </head>
-<body>
-  <div class="container">
+<body class="payment-page">
     <div class="form-card">
       <h1>Создать счёт</h1>
       <form id="payment-form">
@@ -20,8 +19,12 @@
         <input type="text" name="description" required>
       </label>
       <label>
+        Email для чека:
+        <input type="email" name="email" required>
+      </label>
+      <label>
         Вернуть после оплаты на URL:
-        <input type="url" name="return_url" value="https://example.com">
+        <input type="url" name="return_url" placeholder="https://example.com/result.html">
       </label>
       <label>
         Отложенное списание (2 этапа):
@@ -39,7 +42,6 @@
       </form>
       <div id="result" class="hidden"></div>
     </div>
-  </div>
   <script src="admin.js"></script>
 </body>
 </html>

--- a/admin.js
+++ b/admin.js
@@ -1,6 +1,8 @@
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('payment-form');
   const result = document.getElementById('result');
+  // Set default redirect to the status page
+  form.return_url.value = `${window.location.origin}/result.html`;
 
   form.addEventListener('submit', (e) => {
     e.preventDefault();
@@ -9,9 +11,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const query = new URLSearchParams({
       amount: formData.get('amount'),
       description: formData.get('description'),
+      email: formData.get('email'),
       capture: formData.get('capture') ? 'false' : 'true',
       payment_method: formData.get('payment_method'),
-      return_url: formData.get('return_url')
+      return_url: formData.get('return_url') || `${window.location.origin}/result.html`
     });
 
     const link = `${window.location.origin}/invoice.html?${query.toString()}`;

--- a/invoice.html
+++ b/invoice.html
@@ -6,8 +6,7 @@
   <title>Счёт к оплате</title>
   <link rel="stylesheet" href="styles.css">
 </head>
-<body>
-  <div class="container">
+<body class="payment-page">
     <div class="invoice-card" id="invoice">
       <h1>Счёт</h1>
       <p id="description"></p>
@@ -15,7 +14,6 @@
       <button id="pay-btn" class="btn primary-btn">Оплатить</button>
       <div id="message" class="hidden"></div>
     </div>
-  </div>
   <script src="invoice.js"></script>
 </body>
 </html>

--- a/invoice.js
+++ b/invoice.js
@@ -2,6 +2,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const params = new URLSearchParams(window.location.search);
   const amount = params.get('amount');
   const description = params.get('description') || '';
+  const email = params.get('email') || '';
   const capture = params.get('capture') !== 'false';
   const method = params.get('payment_method') || 'bank_card';
   const returnUrl = params.get('return_url') || `${location.origin}/result.html`;
@@ -26,7 +27,16 @@ document.addEventListener('DOMContentLoaded', () => {
           description,
           capture,
           payment_method_types: [method],
-          return_url: returnUrl
+          return_url: returnUrl,
+          receipt: email ? {
+            customer: { email },
+            items: [{
+              description,
+              quantity: '1.0',
+              amount: { value: amount, currency: 'RUB' },
+              vat_code: 1
+            }]
+          } : undefined
         })
       });
       const data = await res.json();

--- a/result.html
+++ b/result.html
@@ -6,12 +6,10 @@
   <title>Статус оплаты</title>
   <link rel="stylesheet" href="styles.css">
 </head>
-<body>
-  <div class="container">
+<body class="payment-page">
     <div id="status" class="status status-card">
       <p>Проверяем статус оплаты...</p>
     </div>
-  </div>
   <script src="result.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -815,7 +815,7 @@ footer {
 .invoice-card,
 .status-card {
     max-width: 500px;
-    margin: 100px auto;
+    margin: 0 auto;
     background-color: var(--card-bg);
     padding: 40px 30px;
     border-radius: 10px;
@@ -864,4 +864,20 @@ footer {
 .invoice-card #message {
     margin-top: 15px;
     color: var(--accent-color);
+}
+
+/* Layout for payment-related pages */
+.payment-page {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+}
+
+.payment-page .form-card,
+.payment-page .invoice-card,
+.payment-page .status-card {
+    margin: 0;
+    width: 100%;
 }


### PR DESCRIPTION
## Summary
- improve layout on payment-related pages so they scale on wide screens
- collect customer email when creating an invoice
- send receipt information to the server when generating a payment
- redirect to the payment status page by default when creating a new invoice

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6844f36033f483259d12ee2ae06b6136